### PR TITLE
Fix bullet spread and chair lean animation

### DIFF
--- a/lua/entities/control_chair.lua
+++ b/lua/entities/control_chair.lua
@@ -1285,27 +1285,17 @@ if SERVER then
             if not self.Enabled and anim == "close" then return end
 
             if (anim == "close") then
+                anim = "open"
                 self:Lean(false)
                 self.Enabled = false
             elseif (anim == "open") then
+                anim = "close"
                 self:Lean(true)
                 self.Enabled = true
             end
             self.Anim = self.Chair:LookupSequence(anim)
-            self.Chair:SetCycle(0) -- Start from the beginning of the animation
             self.Chair:ResetSequenceInfo()
             self.Chair:SetSequence(self.Anim)
-            local animlen = 10
-            -- Set up a timer to advance frames
-            timer.Create("AnimationTimer", 0.01, math.ceil(animlen / 000.1), function()
-                if IsValid(self) and IsValid(self.Chair) then
-                    self.Chair:SetCycle(self.Chair:GetCycle() + 000.1 / animlen)
-                else
-                    timer.Remove("AnimationTimer")
-                end
-            end)
-            
-            
         end
     end
 

--- a/lua/stargate/shared/cap.lua
+++ b/lua/stargate/shared/cap.lua
@@ -272,7 +272,7 @@ hook.Add("EntityFireBullets", "StarGate.EntityFireBullets", function(self, bulle
     local override = false -- If set to true, we will shoot the bullets instead of letting the engine decide
     -- The modified part now, to determine if we hit a shield!
     local spread = bullet.Spread or Vector(0, 0, 0)
-    bullet.Spread = Vector(0, 0, 0)
+    --bullet.Spread = Vector(0, 0, 0) --this breaks shotgun spread and seemingly does nothing else
     local direction = (bullet.Dir or Vector(0, 0, 0))
     local pos = bullet.Src or self:GetPos()
     local rnd = {}


### PR DESCRIPTION
- Fixed all bullet spread being broken (It still doesn't work when going through a gate however)
- Fixed the control chair lean animation resetting to un-leaned state when it finishes leaning back

As far as I can tell, the whole anim length timer was added to make the chair lean back slower, but it seems to break as it doesn't reset properly, and IMO it looks better faster since the ragdoll doesn't anim back, so the chair back goes through the ragdoll even more if its slower