### PR TITLE
City DHD, ZPM Analyzer, and Attero fixes

### DIFF
--- a/lua/entities/attero_device.lua
+++ b/lua/entities/attero_device.lua
@@ -60,7 +60,7 @@ if SERVER then
             self.Mobilegate2 = nil
             self.EntitiesOnRoute = 0
         else
-            self:CreateWireInputs("Activate","ATA Mode")
+            self:CreateWireInputs("Activate","Disable Use","ATA Mode")
         end
         self:CreateWireOutputs("Active")
         self.EntHealth = 100
@@ -358,6 +358,8 @@ if SERVER then
     end
 
     function ENT:Use(p)
+        if(self:GetWire("Disable Use") > 0) then return end
+
         if(self.ATAMode and not StarGate.HasATA(p,true)) then return end
 
         if (self.On) then

--- a/lua/entities/dhd_base/init.lua
+++ b/lua/entities/dhd_base/init.lua
@@ -1136,12 +1136,16 @@ end
 --################# Called by the OnScreen click function @aVoN
 concommand.Remove("_StarGate.DHD.AddSymbol_Group"); -- In case of a lua_reloadents
 concommand.Add("_StarGate.DHD.AddSymbol_Group",
-	function(_,_,arg)
+	function(ply,_,arg)
 		local e = ents.GetByIndex(tonumber(arg[1])); -- Entity
 		if(IsValid(e) and arg[2] and arg[2] ~= "") then
 			local num = tonumber(arg[2]);
 			if(num) then arg[2] = num end; -- If it is a number, we make this string to a number again
-			if not e.busy then e:PressButton(arg[2],false); end
+			if not e.busy then
+				if(e.IsCityDHD and e.ATAMode and not StarGate.HasATA(ply,true)) then return end
+
+				e:PressButton(arg[2],false); 
+			end
 		end
 	end
 );

--- a/lua/entities/dhd_city.lua
+++ b/lua/entities/dhd_city.lua
@@ -268,9 +268,30 @@ if SERVER then
         return e
     end
 
+    function ENT:FindATA(pos)
+        local near = false
+
+        for _, v in pairs(player.GetAll()) do
+            local dist = (pos - v:GetPos()):Length()
+
+            if(dist <= 300) then
+                if(self:GetWire("ATA Mode") > 0) then
+                    if(StarGate.HasATA(v,false)) then
+                        near = true
+                    end
+                else
+                    near = true
+                end
+            end
+        end
+
+        return near
+    end
+
     function ENT:LightThink()
         if (not IsValid(self.Entity)) then return end
-        local ply = StarGate.FindPlayer(self.Entity:GetPos(), 300)
+        
+        local ply = self:FindATA(self.Entity:GetPos())
 
         if (ply and self:GetNWBool("HasEnergy",false))then
             self:ConsumeResource("energy",10)

--- a/lua/entities/zpm_analyser_mk2.lua
+++ b/lua/entities/zpm_analyser_mk2.lua
@@ -184,6 +184,13 @@ if SERVER then
 	end
 
 	function ENT:Think()
+		if(self.ZPM.IsValid and not IsValid(self.ZPM.Ent)) then
+			self.ZPM.IsValid = false
+			self.ZPM.On = false
+			self.CanEject = true
+			self.Percentcomp = 0
+		end
+
 		if self.Active then
 			if CurTime() > self.Time then
 				self.Percentcomp = math.Clamp(self.Percentcomp + math.floor(math.Rand(0.5, 5)) , 0, 100) 
@@ -196,11 +203,14 @@ if SERVER then
 
 			if self.Percentcomp == 100 then
 				self:TurnOff()
-
-				if (self.ZPM.ZPMType == "tampered") then
+				print(self.ZPM.Ent)
+				if(self.ZPM.Ent.ZPMType == "tampered") then
+					print("tamp")
 					self.Entity:SetNWInt("Result",1)
 					self:SetWire("Tainted",1)
 					self:EmitSound("sg/scanner/deactivate2.wav")
+
+					self.ZPM.Ent:SetNWInt("ZPMScannedTainted",1)
 				else
 					self.Entity:SetNWInt("Result",2)
 					self:SetWire("Tainted",0)


### PR DESCRIPTION
- Fixed City DHD light not respecting ATA mode
- Fixed City DHD ATA Mode being bypassable with context menu clicking
- Added disable use input to Attero Device
- Fixed ZPM Analyzer Mk2 not setting the tampered wire output
- Fixed ZPM Analyzer Mk2 not setting a zpm to enable its tampered glow
- Fixed ZPM Analyzer Mk2 not being able to accept new ZPMs if you removed the ZPM that was inside it