### PR TITLE
DHD, and ZPM update

### DIFF
--- a/lua/autorun/stargate.lua
+++ b/lua/autorun/stargate.lua
@@ -190,7 +190,13 @@ if SERVER then
     concommand.Add("stargate_reload", StarGate.CallReload)
 
     --prevent entities inside shields from taking damage, this is probably not the most performant thing, but its probably fine
-    /* --commented because its unfinished, damage sources inside a shield should damage people already inside a shield and this doesnt do that yet
+    --commented because its unfinished, damage sources inside a shield should damage people already inside a shield and this doesnt do that yet
+
+    --shield ent taking damage should damage the shield
+    --shield hit should have debounce because of that
+    
+    --this should probably be remade to every entity checking distance from all shield gens instead of every ent in range
+    /*
     hook.Add("EntityTakeDamage","CAP:E Global Shield Damage Hook",function(target,dmginfo)
         if(target ~= nil) then
             local find = ents.FindInSphere(target:GetPos(),StarGate.CFG:Get("shield","max_size",2048))

--- a/lua/entities/black_hole_power.lua
+++ b/lua/entities/black_hole_power.lua
@@ -131,8 +131,6 @@ if SERVER then
             self.blackHoleMass = self.blackHoleMass + self.bmass
             local size = self.blackHoleMass / 1000
 
-            print("size increase "..size)
-
             self.Entity:SetCollisionBounds(Vector(-size, -size, -size), Vector(size, size, size))
             self.Entity:PhysicsInitSphere(size, "metal_bouncy")
             local phys = self.Entity:GetPhysicsObject()

--- a/lua/entities/dhd_base/init.lua
+++ b/lua/entities/dhd_base/init.lua
@@ -327,7 +327,11 @@ function ENT:TriggerInput(k,v)
 					self:PressButton(self.DialledAddress[table.getn(self.DialledAddress)],nil,true);
 				end
 			elseif(char:find("["..symbols.."]")) then -- Only alphanumerical and the @, #
-				self:PressButton(char,nil,true);
+				if(self.ButtonsMode) then
+					self:ButtonMode(char)
+				else
+					self:PressButton(char,nil,true);
+				end
 			end
 		end
 	elseif (k == "Disable Ring Rotation" or k == "Slow Mode") then

--- a/lua/entities/zpm_mk3.lua
+++ b/lua/entities/zpm_mk3.lua
@@ -51,7 +51,7 @@ if SERVER then
         self.Boom = false
         self.SkinMode = "Normal"
 
-        timer.Simple(0.1,function() --toolgun only sets values after initialize :angy:
+        timer.Simple(0,function() --toolgun only sets values after initialize :angy:
             if(self.ZPMType == "mk4") then
                 self.WireDebugName = "ZPM MK IV"
                 self.Entity:SetModel("models/pg_props/pg_zpm/pg_zpm4.mdl")
@@ -464,7 +464,6 @@ if CLIENT then
 
     function ENT:Draw()
         self.Entity:DrawModel()
-        hook.Remove("HUDPaint", tostring(self.Entity) .. "ZMK")
         if (not StarGate.VisualsMisc("cl_draw_huds", true)) then return end
 
         if (LocalPlayer():GetEyeTrace().Entity == self.Entity and not self.Cloaked and EyePos():Distance(self.Entity:GetPos()) < 1024) then
@@ -513,6 +512,8 @@ if CLIENT then
                 draw.SimpleText(tostring(eng), "center", ScrW() / 2 + 40 + w, ScrH() / 2 + 135 - h, Color(255, 255, 255, 255), 0)
                 draw.SimpleText(tostring(perc) .. "%", "center", ScrW() / 2 + 40 + w, ScrH() / 2 + 185 - h, Color(255, 255, 255, 255), 0)
             end)
+        else
+            hook.Remove("HUDPaint", tostring(self.Entity) .. "ZMK")
         end
         
         render.SetMaterial(self.ZpmSprite)

--- a/lua/entities/zpm_mk4.lua
+++ b/lua/entities/zpm_mk4.lua
@@ -1,6 +1,9 @@
 --[[
 	ZPM MK IV for GarrysMod 10
 	Copyright (C) 2010 Llapp
+
+
+    --Nova Astral / 2026 / 03 / 29 / This entity is deprecated, it only exists now in the unlikely case someone had a dupe with these in it, this entity should be deleted later
 ]]
 if (StarGate ~= nil and StarGate.LifeSupportAndWire ~= nil) then
     StarGate.LifeSupportAndWire(ENT)

--- a/lua/stargate/shared/cap.lua
+++ b/lua/stargate/shared/cap.lua
@@ -568,12 +568,16 @@ permission is the permission name you register in cap_cami.lua
 allowed is what is returned if the player has the permission
 disallowed is what is returned if the player doesn't have the permission
 
-it will always return allowed if CAMI isn't detected (CAMI is included with ULX and most other admin mods)
+it will always return allowed if the player is superadmin or CAMI isn't detected (CAMI is included with ULX and most other admin mods)
 
 possibly this should be updated later to include a 'disallowed error' string which will tell the player they dont have permission to use that
 */
 function StarGate.CheckCami(ply,permission,allowed,disallowed)
     if(ply:IsPlayer() == false) then return end
+
+    if(ply:IsSuperAdmin()) then
+        return allowed
+    end
 
     local ret = disallowed
 

--- a/lua/weapons/adria_dialer.lua
+++ b/lua/weapons/adria_dialer.lua
@@ -100,13 +100,15 @@ end
 if SERVER then
     function SWEP:PrimaryAttack()
         if(self.Active == false) then
+            self:SetNextPrimaryFire(CurTime()+1)
+
             local tr = self.Owner:GetEyeTrace()
             local ent = tr.Entity
             self.tent = tr.Entity
 
-            if(IsValid(ent) and self.Owner:GetShootPos():Distance(tr.HitPos) < 50) then
+            if(IsValid(ent) and self.Owner:GetShootPos():Distance(tr.HitPos) < 50 and table.HasValue(self.DHDs,ent:GetClass())) then
                 local gate = ent:FindGate()
-                if(IsValid(gate) and gate.Active == false and table.HasValue(self.DHDs,ent:GetClass())) then
+                if(IsValid(gate) and gate.Active == false) then
                     self.Active = true
 
                     ent.Disabled = true
@@ -136,6 +138,9 @@ if SERVER then
                         end
                     end)
                 end
+            else
+                self.Owner:SendLua("GAMEMODE:AddNotify('This is not a valid DHD for the Adria Dialer', NOTIFY_GENERIC, 7);")
+                self.Owner:EmitSound("buttons/button18.wav",100,100)
             end
         end
     end


### PR DESCRIPTION
- Made superadmin always pass CAMI checks
- Fixed DHD buttons mode not working with wire keyboard
- Made zpm spawn slightly faster, but mk4 likely still doesnt work in singleplayer
- Made a possible minor optimization to the zpm hud
- Added a comment to the mk4 zpm entity to tell anyone who looks at it that its deprecated
- Added a warning when you click with adria dialer if its not a valid DHD
- Stopped the black hole from printing to console every time it eats something